### PR TITLE
Upgrade to v81

### DIFF
--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -2,7 +2,7 @@
 
 Only code related to the package is in this repository, so you are going to need an Umbraco website of your own to test your changes. After cloning this repository the suggested approach for development is:
 
-1. Create a new Umbraco website (v8.0.0) with the starter kit on your local machine and go through the install process (or use any existing website, so long as it is the correct version of Umbraco)
+1. Create a new Umbraco website (v8.1.0) with the starter kit on your local machine and go through the install process (or use any existing website, so long as it is the correct version of Umbraco)
    
 2. In your cloned version of this repository, copy `src/PostBuildEvents.bat` into the `src/Our.Umbraco.RobotsTxtEditor/` folder
 

--- a/src/Our.Umbraco.RobotsTxtEditor/Our.Umbraco.RobotsTxtEditor.csproj
+++ b/src/Our.Umbraco.RobotsTxtEditor/Our.Umbraco.RobotsTxtEditor.csproj
@@ -187,6 +187,7 @@
     </Reference>
     <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
@@ -194,6 +195,7 @@
     </Reference>
     <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -278,15 +280,19 @@
     <Reference Include="System.Xml" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.8.1.0\lib\net472\Umbraco.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Examine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Our.Umbraco.RobotsTxtEditor/Our.Umbraco.RobotsTxtEditor.csproj
+++ b/src/Our.Umbraco.RobotsTxtEditor/Our.Umbraco.RobotsTxtEditor.csproj
@@ -185,9 +185,15 @@
       <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -271,20 +277,16 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Core.8.1.0\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Examine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Examine.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Our.Umbraco.RobotsTxtEditor/Web/UI/App_Plugins/RobotsTxtEditor/views/robotstxteditor.html
+++ b/src/Our.Umbraco.RobotsTxtEditor/Web/UI/App_Plugins/RobotsTxtEditor/views/robotstxteditor.html
@@ -4,7 +4,6 @@
 
     <div ng-show="!vm.loading">
 
-        <umb-editor-container>
             <umb-box>
                 <umb-box-content>
 
@@ -43,7 +42,6 @@
 
                 </umb-box-content>
             </umb-box>
-        </umb-editor-container>
 
     </div>
 

--- a/src/Our.Umbraco.RobotsTxtEditor/packages.config
+++ b/src/Our.Umbraco.RobotsTxtEditor/packages.config
@@ -44,13 +44,15 @@
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
   <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.3.0" targetFramework="net472" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Map" version="1.0.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
-  <package id="UmbracoCms.Web" version="8.0.0" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.1.0" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.1.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
@leekelleher @MMasey @emmaburstow this PR upgrades the project to use Umbraco 8.1. All seems to still work!  You'll need to upgrade your own test website to be on v8.1 too. 

I also snuck in a tweak to the view to get rid of the empty space at the bottom of the screen that would be where the save button would be, were we putting it there, but we're not. Sorry, terrible practice to do it on same PR I'm sure.

@leekelleher the upgrade removed the '<Private>False</Private>' from my csproj.  I'm not sure there is a difference between this being false, and not being there at all.  Do you?