### PR TITLE
UX improvements

### DIFF
--- a/src/Our.Umbraco.RobotsTxtEditor/Web/UI/App_Plugins/RobotsTxtEditor/js/robotstxteditorController.js
+++ b/src/Our.Umbraco.RobotsTxtEditor/Web/UI/App_Plugins/RobotsTxtEditor/js/robotstxteditorController.js
@@ -1,6 +1,6 @@
 angular.module("umbraco")
     .controller("RobotsTxtEditorController",
-        function ($scope, $routeParams, $timeout, robotsTxtEditorResource, notificationsService, angularHelper) {
+        function (robotsTxtEditorResource, notificationsService) {
 
             var vm = this;
 
@@ -33,6 +33,8 @@ angular.module("umbraco")
 
                     if (vm.editor !== undefined) {
                         vm.editor.setValue(vm.data.FileContents);
+                        vm.editor.navigateFileEnd();
+                        vm.editor.focus();
                     }
 
                     vm.loading = false;
@@ -49,7 +51,7 @@ angular.module("umbraco")
                         notificationsService.success("Saved", "Text saved to Robots.txt");
                     } else {
                         vm.errors = data.ErrorMessages;
-                        notificationsService.error("Validation Error", "There were validation errors");
+                        notificationsService.error("Validation Error", "Robots.txt has not been updated");
                     }
                 });
             }
@@ -65,36 +67,8 @@ angular.module("umbraco")
                     },
                     onLoad: function (_editor) {
                         vm.editor = _editor;
-
-                        // initial cursor placement
-                        // Keep cursor in name field if we are create a new script
-                        // else set the cursor at the bottom of the code editor
-                        if (!$routeParams.create) {
-                            $timeout(function () {
-                                vm.editor.navigateFileEnd();
-                                vm.editor.focus();
-                            });
-                        }
-
-                        vm.editor.on("change", changeAceEditor);
                     }
                 };
-
-                function changeAceEditor() {
-                    setFormState("dirty");
-                }
-
-                function setFormState(state) {
-                    // get the current form
-                    var currentForm = angularHelper.getCurrentForm($scope);
-
-                    // set state
-                    if (state === "dirty") {
-                        currentForm.$setDirty();
-                    } else if (state === "pristine") {
-                        currentForm.$setPristine();
-                    }
-                }
             }
 
             initEditor();


### PR DESCRIPTION
I believe this PR will:

- Stop the text area being highlighted when loaded.  Really annoyed me that page was loading with the text area all blue! Moved the logic for navigating and focusing the editor to be after when the setValue method is called.  Couldn't find any proof that ace's .setValue method was doing the highlight but trial and error seemed to suggest this.  Anyway, it's stopped it happening on my machine!

- Stop any checking of 'isDirty'.  As we can't get it to check that when clicking the other dashboard links I don't think it's the end of the world that we just don't bother with this at all.  i believe it's better to have no prompts re saving changes than annoying ones when you have saved it!

BTW you don't need to have updated your test site to v8.1 to test this one - it will work the same regardless